### PR TITLE
Make Ring of Nutrition work so long as it's worn in a valid slot

### DIFF
--- a/src/main/java/fox/spiteful/lostmagic/LostEvents.java
+++ b/src/main/java/fox/spiteful/lostmagic/LostEvents.java
@@ -40,7 +40,7 @@ public class LostEvents {
                 }
 
                 int slot = BaublesApi.isBaubleEquipped(player, LostItems.ringNutrition);
-                if (slot == 1 || slot == 2) {
+                if (slot >= 0) {
                     player.getFoodStats().addStats(2, 1.0F);
                 }
             }


### PR DESCRIPTION
Bring Me the Rings adds additional Baubles Ring Slots and they are valid ring slots.  The number of slots is configurable, but in any case, slot should never return a valid slot if it is not worn on a Baubles slot.